### PR TITLE
Update production API URL to tillerios.com

### DIFF
--- a/TillerCompanion/Services/APIClient.swift
+++ b/TillerCompanion/Services/APIClient.swift
@@ -12,7 +12,7 @@ struct APIConfig {
     #if DEBUG
     static let baseURL = "http://localhost:8000/api"
     #else
-    static let baseURL = "http://161.35.255.184/api"
+    static let baseURL = "https://tillerios.com/api"
     #endif
 
     static let timeout: TimeInterval = 30.0


### PR DESCRIPTION
Points release builds to https://tillerios.com/api instead of bare IP. Requires DNS + SSL to be configured first.